### PR TITLE
[ViperSwap] Use ViperVote token instead of VIPER for voting

### DIFF
--- a/spaces/viperswap/index.json
+++ b/spaces/viperswap/index.json
@@ -1,13 +1,13 @@
 {
   "name": "ViperSwap",
   "network": "1666600000",
-  "symbol": "VIPER",
+  "symbol": "ViperVote",
   "strategies": [
     {
       "name": "erc20-balance-of",
       "params": {
-        "address": "0xEa589E93Ff18b1a1F1e9BaC7EF3E86Ab62addc79",
-        "symbol": "VIPER",
+        "address": "0x8E8A2799C4E2dADe135519341A67A2b0687feA5a",
+        "symbol": "ViperVote",
         "decimals": 18
       }
     }


### PR DESCRIPTION
We're going to use a dedicated voting token (`0x8E8A2799C4E2dADe135519341A67A2b0687feA5a`) that better represents our users involvement in the ViperSwap ecosystem.

The new ViperVote token's balance consists of:
- 4x of the user's $VIPER position in the $VIPER / $ONE pool
- 2x of the user's $VIPER position in the ViperPit
- 33% of the user's locked $VIPER tokens
- 25% of the user's unlocked $VIPER tokens
