### PR TITLE
Updated FATE-GOV address to use account for xFATE

### DIFF
--- a/spaces/fatexdao/index.json
+++ b/spaces/fatexdao/index.json
@@ -6,7 +6,7 @@
     {
       "name": "erc20-balance-of",
       "params": {
-        "address": "0x43d2Cbe53793DA86FC676A4a69741b1e63AC8b2C",
+        "address": "0x72d2f2d57CC5D3e78c456616E1d17e73e8848c3A",
         "symbol": "FATE-GOV",
         "decimals": 18
       }


### PR DESCRIPTION
#### Hi! What is your PR about?

The voting power token didn't account for xFATE held in LP token pools. This PR fixes that by pointing the snapshot token to a new address with updated logic.